### PR TITLE
Ajoute la mention du nouveau tarif dans le popup d’ouverture

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -97,6 +97,7 @@ const Main = props => {
         <h2 className="major">Disponibilit&eacute;s rapides &ndash; &Eacute;valuations psychosociales</h2>
         <p>Nous sommes actuellement en mesure d&rsquo;offrir rapidement des services d&rsquo;&eacute;valuation psychosociale pour les d&eacute;marches d&rsquo;homologation d&rsquo;un mandat de protection ou d&rsquo;ouverture de tutelle au majeur.</p>
         <p>Un accompagnement professionnel, humain et rigoureux, afin de soutenir les personnes et leurs proches dans ces d&eacute;marches importantes.</p>
+        <p><strong>Veuillez noter que les &eacute;valuations seront au co&ucirc;t de 1500$ plus taxes d&egrave;s le 1er juin 2026.</strong></p>
         {close}
       </article>
 


### PR DESCRIPTION
### Motivation
- Informer les visiteurs, via le popup affiché à l’ouverture du site, que les évaluations seront au coût de 1500$ plus taxes à compter du 1er juin 2026.

### Description
- Ajout d’un paragraphe en gras dans `src/components/Main.js` (article `availability`) contenant la mention tarifaire affichée dans le popup d’ouverture.

### Testing
- Exécution de `npm run build` pour vérifier la compilation échouée dans cet environnement car la commande `gatsby` est introuvable (build non exécutable ici).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c29f7d744c8325b16b3a5a25e35056)